### PR TITLE
First and Second Exercise

### DIFF
--- a/exercise1/Notes/MainPage.xaml
+++ b/exercise1/Notes/MainPage.xaml
@@ -4,5 +4,22 @@
              x:Class="Notes.MainPage">
 			 
    
- 
+ <VerticalStackLayout Margin="30,60,30,30">
+        <Label Text="Notes"
+               HorizontalOptions="Center"
+               FontAttributes="Bold" />
+        <Editor x:Name="editor"
+                Placeholder="Enter your note"
+                HeightRequest="100" />
+        <Grid ColumnDefinitions="Auto, 30, Auto">
+             <Button Grid.Column="0"
+                    Text="Save" 
+                    WidthRequest="100"
+                    Clicked="OnSaveButtonClicked" />
+            <Button Grid.Column="2"
+                    Text="Delete" 
+                     WidthRequest="100"
+                    Clicked="OnDeleteButtonClicked" />
+        </Grid>
+    </VerticalStackLayout>
 </ContentPage>

--- a/exercise1/Notes/MainPage.xaml.cs
+++ b/exercise1/Notes/MainPage.xaml.cs
@@ -3,51 +3,23 @@
 public partial class MainPage : ContentPage
 {
     string _fileName = Path.Combine(FileSystem.AppDataDirectory, "notes.txt");
-    Editor editor;
+
 
     public MainPage()
     {
-        var notesHeading = new Label() { Text = "Notes", HorizontalOptions = LayoutOptions.Center, FontAttributes = FontAttributes.Bold };
-
-        editor = new Editor() { Placeholder = "Enter your note", HeightRequest = 100 };
-        editor.Text = File.Exists(_fileName) ? File.ReadAllText(_fileName) : string.Empty;
-
-        var buttonsGrid = new Grid() { HeightRequest = 40.0 };
-        buttonsGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1.0, GridUnitType.Auto) });
-        buttonsGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(30.0, GridUnitType.Absolute) });
-        buttonsGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1.0, GridUnitType.Auto) });
-
-        var saveButton = new Button() { WidthRequest = 100, Text = "Save" };
-        saveButton.Clicked += OnSaveButtonClicked;
-        Grid.SetColumn(saveButton, 0);
-        buttonsGrid.Children.Add(saveButton);
-
-        var deleteButton = new Button() { WidthRequest = 100, Text = "Delete" };
-        deleteButton.Clicked += OnDeleteButtonClicked;
-        Grid.SetColumn(deleteButton, 2);
-        buttonsGrid.Children.Add(deleteButton);
-
-        var stackLayout = new VerticalStackLayout 
-        { 
-            Padding = new Thickness(30, 60, 30, 30),
-            Children = { notesHeading, editor, buttonsGrid }
-        };
-
-        this.Content = stackLayout;
-    }
-
-    void OnSaveButtonClicked(object sender, EventArgs e)
-    {
-        File.WriteAllText(_fileName, editor.Text);
-    }
-
-    void OnDeleteButtonClicked(object sender, EventArgs e)
-    {
+        InitializeComponent();
         if (File.Exists(_fileName))
         {
-            File.Delete(_fileName);
+            editor.Text = File.ReadAllText(_fileName);
         }
-        editor.Text = string.Empty;
     }
+    public void OnSaveButtonClicked(object sender, System.EventArgs e)
+    {
+
+    }
+    public void OnDeleteButtonClicked(object sender, System.EventArgs e)
+    {
+        editor.Text = "";
+;    }
 }
 

--- a/exercise2/Notes/MainPage.xaml
+++ b/exercise2/Notes/MainPage.xaml
@@ -1,26 +1,34 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Notes.MainPage">
+﻿<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+         xmlns:notes="clr-namespace:Notes"
+         x:Class="Notes.MainPage">
 
     <VerticalStackLayout Padding="30,60,30,30">
         <Label Text="Notes"
-               HorizontalOptions="Center"
-               FontAttributes="Bold" />
+            HorizontalOptions="Center"
+            FontAttributes="Bold" 
+            TextColor="{x:Static Member=notes:SharedResources.FontColor}" />
 
         <Editor x:Name="editor"
                 Placeholder="Enter your note"
-                HeightRequest="100" />
+                HeightRequest="{OnPlatform 100, Android=500, iOS=500}"
+                TextColor="{x:Static Member=notes:SharedResources.FontColor}"
+                />
 
-        <Grid ColumnDefinitions="Auto, 30, Auto">
+        <Grid Grid.Row="2" ColumnDefinitions="Auto,30,Auto">
+
             <Button Grid.Column="0"
-                        Text="Save" 
-                        WidthRequest="100"
-                        Clicked="OnSaveButtonClicked" />
+                    Text="Save" 
+                    WidthRequest="100"
+                    TextColor="{x:Static Member=notes:SharedResources.FontColor}"
+                    BackgroundColor="{x:Static Member=notes:SharedResources.BackgroundColor}"
+                    Clicked="OnSaveButtonClicked" />
 
-            <Button 
+            <Button Grid.Column="2"
                     Text="Delete" 
                     WidthRequest="100"
+                    TextColor="{x:Static Member=notes:SharedResources.FontColor}"
+                    BackgroundColor="{x:Static Member=notes:SharedResources.BackgroundColor}"
                     Clicked="OnDeleteButtonClicked" />
         </Grid>
     </VerticalStackLayout>

--- a/exercise2/Notes/Notes.csproj
+++ b/exercise2/Notes/Notes.csproj
@@ -30,6 +30,9 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0-ios|AnyCPU'">
+	  <CreatePackage>false</CreatePackage>
+	</PropertyGroup>
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />

--- a/exercise2/Notes/SharedResources.cs
+++ b/exercise2/Notes/SharedResources.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Notes
+{
+	static class SharedResources
+	{
+        public static readonly Color FontColor = Color.FromRgb(0, 0, 0xFF);
+        public static readonly Color BackgroundColor = Color.FromRgb(0xFF, 0xF0, 0xAD);
+
+	}
+}
+


### PR DESCRIPTION
# Description
Notes App 
# First Exercise


## Type of change
UI Code removed from the cs file and rewritten in the XAML file 
## How Has This Been Tested?
Tested on Android and iOS

- [ ] iOS

https://github.com/shahrozjan/SecondMAUI-XAML/assets/51943448/d605fd02-7cd4-4953-8b76-a59fea5d7b31

- [ ] Android


https://github.com/shahrozjan/SecondMAUI-XAML/assets/51943448/3172158b-4f1a-4eab-b5a6-9843ea31f408

# Second Exercise


## Type of change
UI Code changed with font and button colours which can be dynamically decided by the CS file through XAML mark-up extensions and different UI spacing on different platforms
## How Has This Been Tested?
Tested on Android and iOS

- [ ] iOS

https://github.com/shahrozjan/SecondMAUI-XAML/assets/51943448/6558d998-f121-4bf4-ae76-96ba5cd5b9cf




- [ ] Android


[Second Exercise.webm](https://github.com/shahrozjan/SecondMAUI-XAML/assets/51943448/b27d1039-f5c9-4188-897b-13a9c390f5d3)



